### PR TITLE
Update pom file to link to github instead of the wiki

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     </developers>
 
 
-    <url>https://wiki.jenkins.io/display/JENKINS/AssertThat+BDD+Jira+Plugin</url>
+    <url>https://github.com/jenkinsci/assertthat-bdd-jira-plugin</url>
     <scm>
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>


### PR DESCRIPTION
Load documentation from Github instead of the wiki.

Related tickets:
https://issues.jenkins-ci.org/browse/WEBSITE-406
https://issues.jenkins-ci.org/browse/JENKINS-59172

More info: https://www.jenkins.io/blog/2019/10/21/plugin-docs-on-github/